### PR TITLE
Remove `main_loop()` assumption for non-Toga builds

### DIFF
--- a/{{ cookiecutter.app_name }}/{{ cookiecutter.app_name }}/__main__.py
+++ b/{{ cookiecutter.app_name }}/{{ cookiecutter.app_name }}/__main__.py
@@ -1,4 +1,8 @@
 from {{ cookiecutter.app_name }}.app import main
 
 if __name__ == '__main__':
+{%- if cookiecutter.gui_framework == 'Toga' %}
     main().main_loop()
+{%- else %}
+    main()
+{%- endif %}

--- a/{{ cookiecutter.app_name }}/{{ cookiecutter.app_name }}/app.py
+++ b/{{ cookiecutter.app_name }}/{{ cookiecutter.app_name }}/app.py
@@ -23,6 +23,6 @@ def main():
     return {{ app_class_name }}('{{ cookiecutter.formal_name }}', '{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}')
 {% else %}
 def main():
-    # This needs to return an object that has a main_loop() method.
-    return None
+    # This should start and launch your app!
+    pass
 {% endif %}


### PR DESCRIPTION
Adjusted Cookiecutter templates to only render `.main_loop()` for actual Toga builds as per discovery with @pvcraven and @DanLindeman